### PR TITLE
Create Contributer Code espbell-lite.yaml

### DIFF
--- a/Code/Contributors_code/espbell-lite.yaml
+++ b/Code/Contributors_code/espbell-lite.yaml
@@ -1,0 +1,89 @@
+substitutions:
+  name: ESP_Intercom
+
+esphome:
+  name: esp_intercom
+  name_add_mac_suffix: false
+
+esp8266:
+  board: esp12e
+
+
+#dashboard_import:
+#  package_import_url: github://PricelessToolkit/ESPBell-LITE/Code/ESPHome/espbell-lite.yaml@main
+#  import_full_config: true
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: 
+
+ota:
+  password: 
+
+wifi:
+  use_address: 
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  fast_connect: true
+  power_save_mode: none
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "${name} Fallback Hotspot"
+    password: 
+
+captive_portal:
+
+web_server:
+  port: 80
+
+sensor:
+
+- platform: uptime
+  name: "${name} uptime"
+  id: uptime_seconds
+  update_interval: 10s
+
+- platform: wifi_signal
+  name: "${name} WiFi Signal"
+
+binary_sensor:
+
+# Doorbell Sensor
+  - platform: gpio
+    pin:
+      number: 4
+      #inverted: true
+    name: "${name} DoorBell"
+    icon: "mdi:bell"
+    filters:
+      delayed_on: 100ms
+
+  - platform: status
+    name: "${name} Status"
+
+switch:
+  - platform: gpio
+    pin: 5
+    id: esp_intercom_relay
+    name: "${name} Relay"
+    icon: "mdi:lock"
+    restore_mode: ALWAYS_OFF
+
+
+button:
+  - platform: template
+    name: "${name} Buzz button"
+    id: esp_intercom_buzz
+    on_press:
+    - switch.turn_on: esp_intercom_relay
+    - delay: 3000ms
+    - switch.turn_off: esp_intercom_relay
+    - logger.log: Button Pressed
+  - platform: restart
+    name: "${name} Restart"
+


### PR DESCRIPTION
My amended code running with an ART930C intercom. I prefer a button setup rather than a momentary switch setup so I have exposed a new button but kept the switch exposed but this could be hidden. I also prefer the restart to be a button and also expose the system as a website incase of failure of the link to home assistant. I would love any suggestions to get the intercom audio working to inject prerecorded or streamed audio and then to listen to the intercom remotely.
I did have this working with my own circuit design on a breadboard with an ESP32 and relays but this product is much simpler and easier. Thanks @PricelessToolkit 
![20231231_161316](https://github.com/PricelessToolkit/ESPBell-LITE/assets/75336029/f66933c5-66b5-42a1-b400-61b110794f17)
