### PR TITLE
Add new OTA password in a comment

### DIFF
--- a/Code/ESPHome/espbell-lite.yaml
+++ b/Code/ESPHome/espbell-lite.yaml
@@ -24,6 +24,8 @@ api:
 
 ota:
 - platform: esphome
+  # For boards after around 2024-10-01:
+  #password: "password"
   password: "54699445e0aab07e709ffadssd188eb0"
 
 


### PR DESCRIPTION
The OTA password on recently shipped boards seems to differ from the config. They seem to use the same password as the fallback AP is configured with (`"password"`). 

```
INFO Uploading firmware.bin (534000 bytes)
INFO Compressed to 372819 bytes
ERROR Error auth result: Error: Authentication invalid. Is the password correct?
```

Given that the repo contains a `firmware.bin` file committed last year, I decided to keep the old password as the config value rather than moving it to a comment. Instead, I added the new OTA password as a comment.

It took me a while to realize the fallback AP password would work, so hopefully, this saves others some time.
